### PR TITLE
Bump kubecost to 1.99

### DIFF
--- a/add-ons/kubecost/Chart.yaml
+++ b/add-ons/kubecost/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "1.0"
 
 dependencies:
   - name: cost-analyzer
-    version: 1.96.0
+    version: 1.99.0
     repository: oci://public.ecr.aws/kubecost


### PR DESCRIPTION
After updating eks from 1.24 to 1.25, ArgoCD can't install kubecost successfully. Based on some investigation I suspect [here](https://docs.kubecost.com/troubleshooting/troubleshoot-install#issue-with-kubernetes-v1.25-helm-commands-fail-when-podsecuritypolicy-crd-is-missing-for-kubecost-gr) is the possible reason. Therefore I'll bump this version for verification.